### PR TITLE
Add minimal web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # AI
+
+This repository contains example code for an extremely simple cryptocurrency exchange.
+
+## Running the example
+
+You can run the FastAPI application by installing the dependencies:
+
+```bash
+pip install -r exchange/requirements.txt
+```
+
+And then start the server:
+
+```bash
+python exchange/app.py
+```
+
+This will launch a development server listening on port 8000.
+
+Open `http://localhost:8000` in your browser to access a minimal GUI for the
+exchange. It lets you view pairs, place orders and inspect the order book.
+
+## Running tests
+
+Unit tests cover the basic order placement and retrieval logic:
+
+```bash
+pytest
+```
+

--- a/exchange/__init__.py
+++ b/exchange/__init__.py
@@ -1,0 +1,1 @@
+"""Crypto exchange package."""

--- a/exchange/app.py
+++ b/exchange/app.py
@@ -1,0 +1,55 @@
+"""Minimal FastAPI application implementing a toy crypto exchange."""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, FileResponse
+from pydantic import BaseModel
+from typing import List
+from pathlib import Path
+
+app = FastAPI(title="Simple Crypto Exchange")
+
+# path to static index.html
+INDEX_FILE = Path(__file__).resolve().parent / "static" / "index.html"
+
+# in-memory order book storage
+ask_orders = []
+bid_orders = []
+
+class Order(BaseModel):
+    user: str
+    pair: str
+    side: str  # 'buy' or 'sell'
+    price: float
+    amount: float
+
+@app.get("/pairs")
+def list_pairs() -> List[str]:
+    return ["BTC-USD", "ETH-USD"]
+
+@app.post("/order")
+def place_order(order: Order):
+    if order.side not in ("buy", "sell"):
+        raise HTTPException(status_code=400, detail="side must be 'buy' or 'sell'")
+    if order.side == "buy":
+        bid_orders.append(order)
+    else:
+        ask_orders.append(order)
+    return {"status": "accepted"}
+
+
+@app.get("/")
+def serve_gui() -> HTMLResponse:
+    """Return the minimal exchange GUI."""
+    return FileResponse(INDEX_FILE)
+
+@app.get("/orderbook/{pair}")
+def get_orderbook(pair: str):
+    if pair not in ["BTC-USD", "ETH-USD"]:
+        raise HTTPException(status_code=404, detail="pair not supported")
+    asks = [o.dict() for o in ask_orders if o.pair == pair]
+    bids = [o.dict() for o in bid_orders if o.pair == pair]
+    return {"asks": asks, "bids": bids}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/exchange/requirements.txt
+++ b/exchange/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/exchange/static/index.html
+++ b/exchange/static/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple Crypto Exchange GUI</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .orders { display: flex; gap: 40px; }
+        table { border-collapse: collapse; width: 300px; }
+        th, td { border: 1px solid #ccc; padding: 4px; text-align: right; }
+    </style>
+</head>
+<body>
+<h1>Simple Crypto Exchange GUI</h1>
+<label for="pair">Trading Pair:</label>
+<select id="pair"></select>
+<br><br>
+<label>Side:
+    <select id="side">
+        <option value="buy">Buy</option>
+        <option value="sell">Sell</option>
+    </select>
+</label>
+<label>Price: <input id="price" type="number" step="0.01"></label>
+<label>Amount: <input id="amount" type="number" step="0.0001"></label>
+<button onclick="placeOrder()">Place Order</button>
+
+<h2>Order Book</h2>
+<div class="orders">
+    <div>
+        <h3>Bids</h3>
+        <table id="bids"><tr><th>User</th><th>Price</th><th>Amount</th></tr></table>
+    </div>
+    <div>
+        <h3>Asks</h3>
+        <table id="asks"><tr><th>User</th><th>Price</th><th>Amount</th></tr></table>
+    </div>
+</div>
+
+<script>
+async function loadPairs() {
+    const res = await fetch('/pairs');
+    const pairs = await res.json();
+    const select = document.getElementById('pair');
+    pairs.forEach(p => {
+        const opt = document.createElement('option');
+        opt.value = p; opt.textContent = p; select.appendChild(opt);
+    });
+    loadOrderbook();
+}
+
+async function loadOrderbook() {
+    const pair = document.getElementById('pair').value;
+    const res = await fetch(`/orderbook/${pair}`);
+    const book = await res.json();
+    populateTable('bids', book.bids);
+    populateTable('asks', book.asks);
+}
+
+function populateTable(id, orders) {
+    const table = document.getElementById(id);
+    table.innerHTML = '<tr><th>User</th><th>Price</th><th>Amount</th></tr>';
+    orders.forEach(o => {
+        const row = table.insertRow();
+        row.insertCell().textContent = o.user;
+        row.insertCell().textContent = o.price;
+        row.insertCell().textContent = o.amount;
+    });
+}
+
+async function placeOrder() {
+    const order = {
+        user: 'alice',
+        pair: document.getElementById('pair').value,
+        side: document.getElementById('side').value,
+        price: parseFloat(document.getElementById('price').value),
+        amount: parseFloat(document.getElementById('amount').value)
+    };
+    await fetch('/order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(order)
+    });
+    document.getElementById('price').value = '';
+    document.getElementById('amount').value = '';
+    loadOrderbook();
+}
+
+document.getElementById('pair').addEventListener('change', loadOrderbook);
+loadPairs();
+</script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "exchange_app", Path(__file__).resolve().parents[1] / "exchange" / "app.py"
+)
+exchange_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(exchange_app)
+
+
+def test_list_pairs():
+    pairs = exchange_app.list_pairs()
+    assert "BTC-USD" in pairs
+
+
+def test_place_and_get_orderbook():
+    # Clear any global state from previous tests
+    exchange_app.ask_orders.clear()
+    exchange_app.bid_orders.clear()
+
+    order = exchange_app.Order(
+        user="alice",
+        pair="BTC-USD",
+        side="buy",
+        price=30000.0,
+        amount=0.5,
+    )
+    exchange_app.place_order(order)
+    orderbook = exchange_app.get_orderbook("BTC-USD")
+    assert any(o["user"] == "alice" for o in orderbook["bids"])
+
+
+def test_gui_served():
+    resp = exchange_app.serve_gui()
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add basic HTML/JS interface to interact with the FastAPI exchange
- serve the GUI from a new root endpoint
- document how to access the GUI
- test that the GUI route works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685673bb87d483299187e3694074f044